### PR TITLE
[Heightmap] Dunes

### DIFF
--- a/noise2d/HeightmapDunes.json
+++ b/noise2d/HeightmapDunes.json
@@ -1,0 +1,305 @@
+{
+   "@collapsed" : false,
+   "@configType" : "NOISE2D",
+   "@name" : "Heightmap - Dunes",
+   "@position" : [ 7932, 8160 ],
+   "@scroll" : [ 8239.9189453125, 8124.81201171875, -0.32500016689300537 ],
+   "@toggle-test" : false,
+   "@toggle-world" : false,
+   "@unlinked" : [],
+   "@version" : 6,
+   "noise2d" : {
+      "@version" : 6,
+      "fun" : {
+         "@collapsed" : false,
+         "@name" : "Sum 2D",
+         "@position" : [ 8250, 8036 ],
+         "frequency" : [ 1, 1 ],
+         "terms" : [
+            {
+               "fun" : {
+                  "@collapsed" : false,
+                  "@name" : "Lerp 2D",
+                  "@position" : [ 8561, 8046 ],
+                  "base" : {
+                     "@collapsed" : false,
+                     "@name" : "Remap 2D",
+                     "@position" : [ 8864, 7923 ],
+                     "clamp" : false,
+                     "clampPower" : 5,
+                     "frequency" : [ 1, 1 ],
+                     "fun" : {
+                        "@collapsed" : false,
+                        "@name" : "Simplex 2D",
+                        "@position" : [ 9146, 7955 ],
+                        "frequency" : [ 0.125, 0.125 ],
+                        "offset" : [ 205.20942687988281, 146.31861877441406 ],
+                        "offset-hash" : "VcM7qWHcmMMjAdAS",
+                        "type" : "simplex"
+                     },
+                     "max" : 1,
+                     "min" : -1,
+                     "type" : "remap"
+                  },
+                  "basePower" : 1,
+                  "f1" : {
+                     "@collapsed" : false,
+                     "@name" : "Constant 2D",
+                     "@position" : [ 8864, 8092 ],
+                     "frequency" : [ 1, 1 ],
+                     "offset" : [ -221.79904174804688, 239.009521484375 ],
+                     "offset-hash" : "h7wn4b1pXKo8llr6",
+                     "type" : "constant",
+                     "value" : -1
+                  },
+                  "f2" : {
+                     "@collapsed" : false,
+                     "@name" : "Basic dunes (Absolute 2D)",
+                     "@position" : [ 8864, 8224 ],
+                     "frequency" : [ 1, 1 ],
+                     "fun" : {
+                        "@collapsed" : false,
+                        "@name" : "Perlin 2D",
+                        "@position" : [ 9146, 8221 ],
+                        "frequency" : [ 0.5, 0.5 ],
+                        "offset" : [ 293.77279663085938, 17.920537948608398 ],
+                        "offset-hash" : "CPWpgVVxOajE0CMi",
+                        "type" : "perlin"
+                     },
+                     "type" : "absolute"
+                  },
+                  "frequency" : [ 1, 1 ],
+                  "type" : "lerp"
+               },
+               "multiplier" : 0.65000003576278687,
+               "power" : 1
+            },
+            {
+               "fun" : {
+                  "@collapsed" : false,
+                  "@name" : "Coarse Variations (Simplex 2D)",
+                  "@position" : [ 8561, 8327 ],
+                  "frequency" : [ 0.25, 0.25 ],
+                  "offset" : [ 272.703125, 132.33529663085938 ],
+                  "offset-hash" : "LvYCiv6zT8f55fOG",
+                  "type" : "simplex"
+               },
+               "multiplier" : 0.35000002384185791,
+               "power" : 1
+            }
+         ],
+         "type" : "sum"
+      },
+      "links" : [
+         {
+            "blockConstraint" : 209752576,
+            "blockDefault" : "",
+            "checkDefault" : true,
+            "linkPath" : [
+               {
+                  "index" : -1,
+                  "name" : "noise2d"
+               },
+               {
+                  "index" : -1,
+                  "name" : "fun"
+               },
+               {
+                  "index" : -1,
+                  "name" : "terms"
+               },
+               {
+                  "index" : 0,
+                  "name" : ""
+               },
+               {
+                  "index" : -1,
+                  "name" : "fun"
+               },
+               {
+                  "index" : -1,
+                  "name" : "base"
+               },
+               {
+                  "index" : -1,
+                  "name" : "max"
+               }
+            ],
+            "linkType" : "LT:CUSTOM_SLIDER",
+            "name" : "Dune Spacing",
+            "shortPath" : "Remap 2D.max",
+            "sliderCheck" : false,
+            "sliderDefault" : 1,
+            "sliderMax" : 2,
+            "sliderMin" : -2,
+            "sliderStep" : 0.0010000000474974513
+         }
+      ]
+   },
+   "seed" : "I has a seed!",
+   "sharedConfig" : {
+      "worldSize" : 288
+   },
+   "test" : {
+      "@collapsed" : false,
+      "@name" : "Reference 2D",
+      "@position" : [ 8250, 8432 ],
+      "embedded" : {
+         "@collapsed" : false,
+         "@configType" : "NOISE2D",
+         "@name" : "Heightmap - Dunes",
+         "@position" : [ 7932, 8160 ],
+         "@toggle-test" : false,
+         "@toggle-world" : false,
+         "@version" : 6,
+         "noise2d" : {
+            "@version" : 6,
+            "fun" : {
+               "@collapsed" : false,
+               "@name" : "Sum 2D",
+               "@position" : [ 8250, 8036 ],
+               "frequency" : [ 1, 1 ],
+               "terms" : [
+                  {
+                     "fun" : {
+                        "@collapsed" : false,
+                        "@name" : "Lerp 2D",
+                        "@position" : [ 8561, 8046 ],
+                        "base" : {
+                           "@collapsed" : false,
+                           "@name" : "Remap 2D",
+                           "@position" : [ 8864, 7923 ],
+                           "clamp" : false,
+                           "clampPower" : 5,
+                           "frequency" : [ 1, 1 ],
+                           "fun" : {
+                              "@collapsed" : false,
+                              "@name" : "Simplex 2D",
+                              "@position" : [ 9146, 7955 ],
+                              "frequency" : [ 0.125, 0.125 ],
+                              "offset" : [ 205.20942687988281, 146.31861877441406 ],
+                              "offset-hash" : "VcM7qWHcmMMjAdAS",
+                              "type" : "simplex"
+                           },
+                           "max" : 1,
+                           "min" : -1,
+                           "type" : "remap"
+                        },
+                        "basePower" : 1,
+                        "f1" : {
+                           "@collapsed" : false,
+                           "@name" : "Constant 2D",
+                           "@position" : [ 8864, 8092 ],
+                           "frequency" : [ 1, 1 ],
+                           "offset" : [ -221.79904174804688, 239.009521484375 ],
+                           "offset-hash" : "h7wn4b1pXKo8llr6",
+                           "type" : "constant",
+                           "value" : -1
+                        },
+                        "f2" : {
+                           "@collapsed" : false,
+                           "@name" : "Basic dunes (Absolute 2D)",
+                           "@position" : [ 8864, 8224 ],
+                           "frequency" : [ 1, 1 ],
+                           "fun" : {
+                              "@collapsed" : false,
+                              "@name" : "Perlin 2D",
+                              "@position" : [ 9146, 8221 ],
+                              "frequency" : [ 0.5, 0.5 ],
+                              "offset" : [ 293.77279663085938, 17.920537948608398 ],
+                              "offset-hash" : "CPWpgVVxOajE0CMi",
+                              "type" : "perlin"
+                           },
+                           "type" : "absolute"
+                        },
+                        "frequency" : [ 1, 1 ],
+                        "type" : "lerp"
+                     },
+                     "multiplier" : 0.65000003576278687,
+                     "power" : 1
+                  },
+                  {
+                     "fun" : {
+                        "@collapsed" : false,
+                        "@name" : "Coarse Variations (Simplex 2D)",
+                        "@position" : [ 8561, 8327 ],
+                        "frequency" : [ 0.25, 0.25 ],
+                        "offset" : [ 272.703125, 132.33529663085938 ],
+                        "offset-hash" : "LvYCiv6zT8f55fOG",
+                        "type" : "simplex"
+                     },
+                     "multiplier" : 0.35000002384185791,
+                     "power" : 1
+                  }
+               ],
+               "type" : "sum"
+            },
+            "links" : [
+               {
+                  "blockConstraint" : 209752576,
+                  "blockDefault" : "",
+                  "checkDefault" : true,
+                  "linkPath" : [
+                     {
+                        "index" : -1,
+                        "name" : "noise2d"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "fun"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "terms"
+                     },
+                     {
+                        "index" : 0,
+                        "name" : ""
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "fun"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "base"
+                     },
+                     {
+                        "index" : -1,
+                        "name" : "max"
+                     }
+                  ],
+                  "linkType" : "LT:CUSTOM_SLIDER",
+                  "name" : "Dune Spacing",
+                  "shortPath" : "Remap 2D.max",
+                  "sliderCheck" : false,
+                  "sliderDefault" : 1,
+                  "sliderMax" : 2,
+                  "sliderMin" : -2,
+                  "sliderStep" : 0.0010000000474974513
+               }
+            ]
+         },
+         "seed" : "I has a seed!",
+         "sharedConfig" : {
+            "worldSize" : 288
+         },
+         "test" : {
+            "@collapsed" : false,
+            "@name" : "Reference 2D",
+            "@position" : [ 8250, 8432 ],
+            "frequency" : [ 1, 1 ],
+            "offset" : [ -178.15823364257812, -127.09002685546875 ],
+            "offset-hash" : "vsl5qH74m2bt8IFq",
+            "type" : "reference"
+         }
+      },
+      "frequency" : [ 1, 1 ],
+      "links" : [],
+      "offset" : [ -178.15823364257812, -127.09002685546875 ],
+      "offset-hash" : "vsl5qH74m2bt8IFq",
+      "reference" : "",
+      "tick" : 0,
+      "type" : "reference"
+   }
+}


### PR DESCRIPTION
For all your desert needs!  Behold, dunes:

![image](https://cloud.githubusercontent.com/assets/41373/16346944/e1c2c0e8-39fe-11e6-8b4c-0302cffaf23b.png)

The function exposes a "Dune Spacing" slider, which you can use to choose how frequently dunes appear in the overall heightmap.  Larger values means fewer dunes, and more rolling sand in between them.

Works best when the heightmap has a range of about 15 blocks.
